### PR TITLE
Allow python 3.7 and above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
       - name: install
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt pytest==6.2.1 responses==0.5.1 flake8==3.8.4
+          pip install -r requirements.txt pytest==6.2.1 responses==0.12.1 flake8==3.8.4
 
       - name: lint
         run: flake8

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Full documentation: <https://messente.com/documentation>
 The library can be installed/upgraded via pip:
 
 ```
-pip install messente-python==2.0.0
+pip install messente-python==2.0.1
 ```
 
 or by using setuptools:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # messente-python
 
-Messente SMS API library for Python 3.6.
+Messente SMS API library for Python 3.6 and up but not Python 4.
 
 Full documentation: <https://messente.com/documentation>
 
@@ -39,8 +39,8 @@ Configuration can be stored in a *.ini file (please see config.sample.ini).
 The path to the file can be passed to a contructor as "ini_path" keyword argument:
 
 ```python
-    import messente
-    api = messente.Messente(ini_path="some/path/filename.ini")
+from messente.api.sms import Messente
+api = messente.Messente(ini_path="some/path/filename.ini")
 ```
 
 Configuration file is divided into following sections:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # messente-python
 
-Messente SMS API library for Python 3.6 and up but not Python 4.
+Messente SMS API library for Python 3.6+.
 
 Full documentation: <https://messente.com/documentation>
 

--- a/messente/api/sms/__init__.py
+++ b/messente/api/sms/__init__.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms import api
 from messente.api.sms.constants import VERSION
 from messente.api.sms.messente import Messente

--- a/messente/api/sms/api/__init__.py
+++ b/messente/api/sms/api/__init__.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms.api import error
 from messente.api.sms.api.response import Response
 

--- a/messente/api/sms/api/api.py
+++ b/messente/api/sms/api/api.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import requests
 

--- a/messente/api/sms/api/config.py
+++ b/messente/api/sms/api/config.py
@@ -14,15 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import os
 from messente.api.sms.api.error import ConfigurationError
 from messente.api.sms.logging import log
 
-from six.moves import configparser
+import configparser
 
-configuration = configparser.SafeConfigParser()
+configuration = configparser.ConfigParser()
 
 configuration.add_section("api")
 configuration.add_section("sms")

--- a/messente/api/sms/api/credit.py
+++ b/messente/api/sms/api/credit.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms.api import api
 from messente.api.sms.api.response import Response
 

--- a/messente/api/sms/api/delivery.py
+++ b/messente/api/sms/api/delivery.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms.api import api
 from messente.api.sms.api.error import ERROR_CODES
 from messente.api.sms.api.response import Response

--- a/messente/api/sms/api/number_verification.py
+++ b/messente/api/sms/api/number_verification.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms.api import api
 from messente.api.sms.api import utils
 from messente.api.sms.api.error import ERROR_CODES

--- a/messente/api/sms/api/pricing.py
+++ b/messente/api/sms/api/pricing.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms.api import api
 from messente.api.sms.api import utils
 from messente.api.sms.api.error import ApiError

--- a/messente/api/sms/api/response.py
+++ b/messente/api/sms/api/response.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms.api.error import ERROR_CODES
 
 

--- a/messente/api/sms/api/sms.py
+++ b/messente/api/sms/api/sms.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from builtins import (str, super, int)
 
 from messente.api.sms.api import api

--- a/messente/api/sms/api/verification_widget.py
+++ b/messente/api/sms/api/verification_widget.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import hashlib
 
 from messente.api.sms.api import api

--- a/messente/api/sms/constants.py
+++ b/messente/api/sms/constants.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"

--- a/messente/api/sms/constants.py
+++ b/messente/api/sms/constants.py
@@ -14,6 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 VERSION = "2.0.0"

--- a/messente/api/sms/logging.py
+++ b/messente/api/sms/logging.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 log = logging.getLogger("messente")

--- a/messente/api/sms/messente.py
+++ b/messente/api/sms/messente.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, print_function
-
 from messente.api.sms import api
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-requests==2.20.0
-six==1.10.0
-future==0.16.0
+requests==2.*

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     keywords="messente sms verification 2FA pincode",
     url="http://messente.com/documentation/",
     test_suite="messente.api.sms.test",
-    python_requires="==3.6.*",
+    python_requires="~=3.6",
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown'
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('README.md') as readme_file:
 
 setup(
     name="messente-python",
-    version="2.0.0",
+    version="2.0.1",
     packages=["messente.api.sms", "messente.api.sms.api"],
     install_requires=PROD_REQUIREMENTS,
     author="Messente.com",


### PR DESCRIPTION
Previously tests with higher python failed because of "responses==0.5.1" testing library


Deleted the usage of `future` and `six` dependencies.